### PR TITLE
Recognize jed/xjed as text document editor

### DIFF
--- a/bin/docfd.ml
+++ b/bin/docfd.ml
@@ -348,6 +348,10 @@ let open_text_path index document_src ~editor ~path ~search_result =
           Fmt.str "%s +%d %s" editor line_num path
         | "micro" ->
           Fmt.str "%s %s:%d" editor path line_num
+        | "jed" ->
+          Fmt.str "%s %s -g %d" editor path line_num
+        | "xjed" ->
+          Fmt.str "%s %s -g %d" editor path line_num
         | _ ->
           fallback
       )


### PR DESCRIPTION
The [jed](https://www.jedsoft.org/jed/) text editor (and its graphic sibling xjed) uses `jed $FILE -g $LINENO` to open `$FILE` and position the cursor at line number `$LINENO`.

This pull-request will allow `docfd` to use `jed` or `xjed` to open a text file.

Disclaimer: I don't speak OCaml at all, and I haven't tested the patch, I've merely copied the existing pattern.
