### PR TITLE
added pdf viewer integration for zathura

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.0.1
 
 - Added missing sorting based on paths when path dates are the same
+- Added PDF viewer integration for zathura
 
 ## 12.0.0
 

--- a/bin/path_opening.ml
+++ b/bin/path_opening.ml
@@ -274,6 +274,11 @@ let pdf_config_and_cmd ~doc_id ~path ~search_result : Config.t * string =
                 else if contains "atril" then
                   make_command "atril"
                     "--page-index {page_num} --find {search_word} {path}"
+                (*note: keep this _before_ mupdf, since zathura might be
+                 `org.pwmt.zathura-pdf-mupdf.desktop`*)
+                else if contains "zathura" then
+                  make_command "zathura"
+                    "--page {page_num} --find {search_word} {path}"
                 else if contains "mupdf" then
                   make_command "mupdf" "{path} {page_num}"
                 else


### PR DESCRIPTION
Hey, I was just playing around with `docfd` and figured I would add support for the PDF viewer I'm using: [`zathura`](https://pwmt.org/projects/zathura/).
Not sure what you're approach for maintaining the changelog and the wiki are, I added a line to the changelog, but can't edit the wiki. Let me know if you want me to adjust anything.

The case for `zathura` is intentionally place _before_ `mupdf`, since the result of `xdg-mime query default application/pdf` for me is `org.pwmt.zathura-pdf-mupdf.desktop`, which triggered `docfd` to attempt to use `mupdf` on my system, rather than the fallback via `xdg-open`.